### PR TITLE
chore: Unify windows builder script with ci-tools.

### DIFF
--- a/platform/windows/cross-compile/build.sh
+++ b/platform/windows/cross-compile/build.sh
@@ -124,7 +124,6 @@ cp "$PROJECT_BUILD_DIR/$BINARY_NAME.exe" "$PROJECT_PREFIX_DIR"
 
 # Always needed DLLs.
 DLL_DEPS=(
-  libssp-0.dll
   libstdc++-6.dll
   libwinpthread-1.dll
 )

--- a/platform/windows/cross-compile/dll-deps
+++ b/platform/windows/cross-compile/dll-deps
@@ -14,4 +14,5 @@ tls/qcertonlybackend.dll
 # Toxcore dependencies.
 libopus-0.dll
 libsodium-26.dll
+libssp-0.dll
 libtoxcore.dll


### PR DESCRIPTION
This way we can use the ci-tools one and delete the local one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/debugtox/17)
<!-- Reviewable:end -->
