### PR TITLE
fix: Adapt to Qt 6.9

### DIFF
--- a/src/models/bytes/bytearray.cpp
+++ b/src/models/bytes/bytearray.cpp
@@ -14,7 +14,8 @@ QString ByteArray::toString() const
         if (c.isPrint() || c.isSpace()) {
             result += c;
         } else {
-            result += QStringLiteral("\\x%1").arg(c.unicode(), 2, 16, QLatin1Char('0'));
+            result += QStringLiteral("\\x%1").arg(static_cast<quint16>(c.unicode()), 2, 16,
+                                                  QLatin1Char('0'));
         }
     }
     return result;


### PR DESCRIPTION
QString[Literal]::arg() integral signatures no longer accept sting-ish types like char16_t, as returned by QChar::unicode(), in Qt 6.9. [1]

Cast the sting-ish char16_t to quint16 to disambiguate and avoid compilation errors.

[1] https://code.qt.io/cgit/qt/qtbase.git/commit/?h=6.9.0&id=563ed822f86

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/debugtox/23)
<!-- Reviewable:end -->
